### PR TITLE
Replace deprecated tag in `plugin.json`.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -16,7 +16,7 @@
       "slug": "cyc-strong_kar",
       "name": "Strong Kar",
       "description": "Implementation of the Karplus-Strong algorithm",
-      "tags": ["VCO"]
+      "tags": ["Oscillator"]
     }
   ]
 }


### PR DESCRIPTION
Rack has deprecated the `VCO` tag in favor of the `Oscillator` tag.